### PR TITLE
fix: missing labels in charts (#257)

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-invalid-this */
 
 // Import Internal Dependencies
-import "../lib/chart.js";
 import { md5 } from "../lib/md5.js";
 
 // Import ESBUILD Assets
@@ -12,7 +11,15 @@ const kChartOptions = {
   legend: {
     display: false
   },
+  scales: {
+    y: {
+      beginAtZero: true
+    }
+  },
   plugins: {
+    legend: {
+      display: true
+    },
     datalabels: {
       anchor: "center",
       textShadowBlur: 4,
@@ -51,18 +58,28 @@ function* interpolateColors(dataLength, scale, range) {
 function createChart(elementId, type = "bar", payload = {}) {
   const { labels, data, interpolate = d3.interpolateCool } = payload;
   const options = JSON.parse(JSON.stringify(kChartOptions));
+  const chartType = (type === "horizontalBar") ? "bar" : type;
+  if (type === "horizontalBar") {
+    options.indexAxis = "y";
+  }
   if (type === "pie") {
     options.legend.display = true;
     options.plugins.datalabels.align = "center";
   }
   else {
+    options.plugins.legend.display = false;
     options.plugins.datalabels.align = type === "bar" ? "top" : "right";
   }
 
   new Chart(document.getElementById(elementId).getContext("2d"), {
-    type,
+    type: chartType,
+    plugins: [ChartDataLabels],
     data: {
+      label: "",
       labels,
+      legend: {
+        display: false
+      },
       datasets: [{
         borderWidth: 0,
         backgroundColor: [...interpolateColors(labels.length, interpolate, colorRangeInfo)],
@@ -85,10 +102,6 @@ function nodeDepClick() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  Chart.Legend.prototype.afterFit = function afterFit() {
-    this.height += 15;
-  };
-
   const avatarsElements = document.querySelectorAll(".avatar");
   for (const avatar of avatarsElements) {
     const email = avatar.getAttribute("data-email");

--- a/views/template.html
+++ b/views/template.html
@@ -7,7 +7,9 @@
     href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,500,500i,700,700i&display=swap" />
 <link href="../public/css/themes/[[=z.report_theme]].css" rel="stylesheet" type="text/css">
 <link href="../public/css/style.css" rel="stylesheet" type="text/css">
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0/dist/chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
+
 <script src="https://d3js.org/d3-color.v1.min.js"></script>
 <script src="https://d3js.org/d3-interpolate.v1.min.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>


### PR DESCRIPTION
Update Chart.js version because the version was incompatible with chartjs-plugins-datalabels.