### PR TITLE
feat(api): saveHTMLOnDisk option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,22 @@ export interface ReportChart {
 }
 
 export interface ReportOptions {
+  /**
+   * Location where the report will be saved.
+   * 
+   * If not provided, default to cwd if HTML or PDF is saved on disk, or a temp directory else.
+   */
   reportOutputLocation?: string | null;
   /**
-   * Save the PDF on disk (in the current working directory)
+   * Save the PDF on disk
    * @default false
    */
   savePDFOnDisk?: boolean;
+  /**
+   * Save the HTML on disk
+   * @default false
+   */
+  saveHTMLOnDisk?: boolean;
 }
 ```
 

--- a/test/api/report.spec.js
+++ b/test/api/report.spec.js
@@ -2,6 +2,7 @@
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import { describe, test } from "node:test";
 import assert from "node:assert";
 
@@ -51,8 +52,8 @@ const kReportPayload = {
   ]
 };
 
-describe("(API) report", () => {
-  test("Given a scanner Payload it should successfully generate a PDF", async() => {
+describe("(API) report", { concurrency: 1 }, () => {
+  test("it should successfully generate a PDF and should not save PDF or HTML", async() => {
     const reportOutputLocation = await fs.mkdtemp(
       path.join(os.tmpdir(), "test-runner-report-pdf-")
     );
@@ -72,12 +73,77 @@ describe("(API) report", () => {
         .flatMap((dirent) => (dirent.isFile() ? [dirent.name] : []));
       assert.deepEqual(
         files,
+        []
+      );
+    }
+    finally {
+      await fs.rm(reportOutputLocation, { force: true, recursive: true });
+    }
+  });
+
+  test("should save HTML when saveHTMLOnDisk is truthy", async() => {
+    const reportOutputLocation = await fs.mkdtemp(
+      path.join(os.tmpdir(), "test-runner-report-pdf-")
+    );
+
+    const payload = await from("sade");
+
+    const generatedPDF = await report(
+      payload.dependencies,
+      { ...kReportPayload, reporters: ["pdf", "html"] },
+      { reportOutputLocation, saveHTMLOnDisk: true }
+    );
+    try {
+      assert.ok(Buffer.isBuffer(generatedPDF));
+      assert.ok(isPDF(generatedPDF));
+
+      const files = (await fs.readdir(reportOutputLocation, { withFileTypes: true }))
+        .flatMap((dirent) => (dirent.isFile() ? [dirent.name] : []));
+      assert.deepEqual(
+        files,
         ["test_runner.html"]
       );
     }
     finally {
       await fs.rm(reportOutputLocation, { force: true, recursive: true });
     }
+  });
+
+  test("should save PDF when savePDFOnDisk is truthy", async() => {
+    const reportOutputLocation = await fs.mkdtemp(
+      path.join(os.tmpdir(), "test-runner-report-pdf-")
+    );
+
+    const payload = await from("sade");
+
+    const generatedPDFPath = await report(
+      payload.dependencies,
+      { ...kReportPayload, reporters: ["pdf", "html"] },
+      { reportOutputLocation, savePDFOnDisk: true }
+    );
+    try {
+      assert.ok(typeof generatedPDFPath === "string");
+      assert.ok(fsSync.existsSync(generatedPDFPath), "when saving PDF, we return the path to the PDF instead of the buffer");
+
+      const files = (await fs.readdir(reportOutputLocation, { withFileTypes: true }))
+        .flatMap((dirent) => (dirent.isFile() ? [dirent.name] : []));
+      assert.deepEqual(
+        files,
+        ["test_runner.pdf"]
+      );
+    }
+    finally {
+      await fs.rm(reportOutputLocation, { force: true, recursive: true });
+    }
+  });
+
+  test("should throw when no reporter is enabled", async() => {
+    const payload = await from("sade");
+
+    await assert.rejects(
+      () => report(payload.dependencies, { ...kReportPayload, reporters: [] }),
+      { message: "At least one reporter must be enabled (pdf or html)" }
+    );
   });
 });
 


### PR DESCRIPTION
When `savePDFOnDisk` was truthy and no `reportOutputLocation` was given, we generated the PDF in the temp folder which is not practical.

I've added a new option `saveHTMLOnDisk` and changed this behavior.
- if a least one report file must be saved (`savePDFOnDisk` or `saveHTMLOnDisk`) then we don't fallback `reportOutputLocation` to the temp directory but CWD instead.
- we remove the created HTML report when the new option `saveHTMLOnDisk` is falsy (by default).