### PR TITLE
test(e2e): add nominal tests for exec & init CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,9 @@ json/
 reports/
 preview/
 dist/
-.nodesecurerc
+/.nodesecurerc
 .DS_Store
+
+# IDE
+.vscode
+jsconfig.json

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint src test bin scripts",
     "test-only": "glob -c \"tsx --test-reporter=spec --test\" \"./test/**/*.spec.ts\"",
     "test": "c8 --all --src ./src -r html npm run test-only",
+    "test:e2e": "glob -c \"tsx -r dotenv/config --test-reporter=spec --test\" \"./test/**/*.e2e-spec.ts\"",
     "preview:light": "tsx --no-warnings ./scripts/preview.js --theme light",
     "preview:dark": "tsx --no-warnings ./scripts/preview.js --theme dark",
     "prepublishOnly": "npm run build"

--- a/test/commands/execute.e2e-spec.ts
+++ b/test/commands/execute.e2e-spec.ts
@@ -1,0 +1,63 @@
+// Import Node.js Dependencies
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { stripVTControlCharacters } from "node:util";
+
+// Import Internal Dependencies
+import { filterProcessStdout } from "../helpers/reportCommandRunner.js";
+import * as CONSTANTS from "../../src/constants.js";
+
+// CONSTANTS
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const kProcessDir = path.join(__dirname, "../..");
+
+describe("Report execute command", () => {
+  afterEach(async() => await fs.rm(CONSTANTS.DIRS.CLONES, {
+    recursive: true, force: true
+  }));
+
+  it("should execute command on fixture '.nodesecurerc'", async() => {
+    const options = {
+      cmd: "node",
+      args: ["dist/bin/index.js", "execute"],
+      cwd: kProcessDir
+    };
+
+    function byMessage(buffer) {
+      const message = ".*";
+      const afterNonAlphaNum = String.raw`?<=[^a-zA-Z\d\s:]\s`;
+      const beforeTime = String.raw`?=\s\d{1,5}.\d{1,4}ms`;
+      const withoutDuplicates = String.raw`(?![\s\S]*\1)`;
+
+      const matchMessage = `(${afterNonAlphaNum})(${message})(${beforeTime})|(${afterNonAlphaNum})(${message})`;
+      const reg = new RegExp(`(${matchMessage})${withoutDuplicates}`, "g");
+
+      const matchedMessages = stripVTControlCharacters(buffer.toString()).match(reg);
+
+      return matchedMessages ?? [""];
+    }
+
+    const expectedLines = [
+      `Executing nreport at: ${kProcessDir}`,
+      "title: Default report title",
+      "reporters: html,pdf",
+      "[Fetcher: NPM] - Fetching NPM packages metadata on the NPM Registry",
+      "",
+      "[Fetcher: NPM] - successfully executed in",
+      "[Fetcher: GIT] - Cloning GIT repositories",
+      "[Fetcher: GIT] - Fetching repositories metadata on the NPM Registry",
+      "[Fetcher: GIT] - successfully executed in",
+      "[Reporter: HTML] - Building template and assets",
+      "[Reporter: HTML] - successfully executed in",
+      "[Reporter: PDF] - Using puppeteer to convert HTML content to PDF",
+      "[Reporter: PDF] - successfully executed in",
+      "Security report successfully generated! Enjoy 🚀."
+    ];
+
+    const actualLines = await filterProcessStdout(options, byMessage);
+    assert.deepEqual(actualLines, expectedLines, "we are expecting these lines");
+  });
+});

--- a/test/commands/initialize.e2e-spec.ts
+++ b/test/commands/initialize.e2e-spec.ts
@@ -1,0 +1,50 @@
+// Import Node.js Dependencies
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { before, describe, it } from "node:test";
+import assert from "node:assert";
+import { stripVTControlCharacters } from "node:util";
+
+// Import Internal Dependencies
+import { runProcess } from "../helpers/reportCommandRunner.js";
+
+// CONSTANTS
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const kBinDir = path.join(__dirname, "../..", "dist/bin/index.js");
+const kProcessDir = os.tmpdir();
+const kConfigFilePath = path.join(kProcessDir, ".nodesecurerc");
+
+describe("Report init command if config does not exists", () => {
+  before(() => {
+    if (fs.existsSync(kConfigFilePath)) {
+      fs.unlinkSync(kConfigFilePath);
+    }
+  });
+
+  it("should create config if not exists", async() => {
+    const lines = [
+      /.*/,
+      / > Executing nreport at: .*$/,
+      /.*/,
+      /Successfully generated NodeSecure runtime configuration at current location/,
+      /.*/
+    ];
+
+    const processOptions = {
+      cmd: "node",
+      args: [kBinDir, "initialize"],
+      cwd: kProcessDir
+    };
+
+    for await (const line of runProcess(processOptions)) {
+      const regexp = lines.shift();
+      assert.ok(regexp, "we are expecting this line");
+      assert.ok(regexp.test(stripVTControlCharacters(line)), `line (${line}) matches ${regexp}`);
+    }
+
+    // to prevent false positive if no lines have been emitted from process
+    assert.equal(lines.length, 0);
+  });
+});

--- a/test/fixtures/.nodesecurerc
+++ b/test/fixtures/.nodesecurerc
@@ -1,0 +1,42 @@
+{
+  "version": "1.0.0",
+  "i18n": "english",
+  "strategy": "github-advisory",
+  "registry": "https://registry.npmjs.org",
+  "report": {
+    "theme": "light",
+    "includeTransitiveInternal": false,
+    "reporters": [
+      "html",
+      "pdf"
+    ],
+    "charts": [
+      {
+        "name": "Extensions",
+        "display": true,
+        "interpolation": "d3.interpolateRainbow",
+        "type": "bar"
+      },
+      {
+        "name": "Licenses",
+        "display": true,
+        "interpolation": "d3.interpolateCool",
+        "type": "bar"
+      },
+      {
+        "name": "Warnings",
+        "display": true,
+        "type": "horizontalBar",
+        "interpolation": "d3.interpolateInferno"
+      },
+      {
+        "name": "Flags",
+        "display": true,
+        "type": "horizontalBar",
+        "interpolation": "d3.interpolateSinebow"
+      }
+    ],
+    "title": "Default report title",
+    "showFlags": true
+  }
+}

--- a/test/helpers/reportCommandRunner.ts
+++ b/test/helpers/reportCommandRunner.ts
@@ -1,0 +1,54 @@
+// Import Node.js Dependencies
+import { ChildProcess, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { stripVTControlCharacters } from "node:util";
+
+export async function* runProcess(options) {
+  const childProcess = spawnedProcess(options);
+  try {
+    if (!childProcess.stdout) {
+      return;
+    }
+
+    const rStream = createInterface(childProcess.stdout);
+
+    for await (const line of rStream) {
+      yield stripVTControlCharacters(line);
+    }
+  }
+  finally {
+    childProcess.kill();
+  }
+}
+
+export function filterProcessStdout(options, filter): Promise<string[]> {
+  const { resolve, reject, promise } = Promise.withResolvers<string[]>();
+
+  const childProcess = spawnedProcess(options);
+  const output = new Set<string>();
+
+  childProcess.stdout?.on("data", (buffer) => {
+    filter(buffer).forEach((filteredData) => {
+      output.add(filteredData);
+    });
+  });
+
+  childProcess.on("close", () => {
+    resolve(Array.from(output));
+  });
+
+  childProcess.on("error", (err) => {
+    reject(err);
+  });
+
+  return promise;
+}
+
+function spawnedProcess(options): ChildProcess {
+  const { cmd, args = [], cwd = process.cwd() } = options;
+
+  return spawn(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    cwd
+  });
+}


### PR DESCRIPTION
TOFIX: could run tests before TS migration, now something goes wrong with childprocess and execution path.

when running nreport init, main process throws the same error :
Error: ENOENT: no such file or directory, open 'C:\<yourDevDir>\report\dist\views\template.html'

process try to access views from dist folder but it does not exists, should be added to dist folder as asset in tsconfig file to include a copy when compiling typescript
