### PR TITLE
refactor(test): replace dotenv with native Node.js env file loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint src test bin scripts",
     "test-only": "node --test-reporter=spec --test ./test/**/*.spec.ts",
     "test": "c8 --all --src ./src -r html npm run test-only",
-    "test:e2e": "node -r dotenv/config --test-reporter=spec --test ./test/**/*.e2e-spec.ts",
+    "test:e2e": "node --env-file-if-exists=.env --test-reporter=spec --test ./test/**/*.e2e-spec.ts",
     "preview:light": "node --no-warnings ./scripts/preview.ts --theme light",
     "preview:dark": "node --no-warnings ./scripts/preview.ts --theme dark",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
Simply uses the use Node.js native --env-file flag instead of dotenv (which was a transitive dependancy by `@nodesecure/ossf-scorecard-sdk`)