### PR TITLE
fix: update @nodesecure/scanner to v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is designed to generate periodic security reports in both HTML and 
 
 ## Features
 
-- Automatically clones and scans Git repositories using **scanner.cwd**.
+- Automatically clones and scans Git repositories using **scanner.workingDir**.
 - Provides a visual overview of **security threats** and quality issues for multiple Git or NPM packages.
 - Facilitates visualization of changes over time.
 - Generates reports in both **HTML** and **PDF** formats.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nodesecure/flags": "^3.0.3",
     "@nodesecure/ossf-scorecard-sdk": "^3.2.1",
     "@nodesecure/rc": "^5.0.0",
-    "@nodesecure/scanner": "^9.0.0",
+    "@nodesecure/scanner": "^10.0.0",
     "@nodesecure/utils": "^2.2.0",
     "@openally/mutex": "^2.0.0",
     "@topcli/spinner": "^4.0.0",

--- a/src/analysis/scanner.ts
+++ b/src/analysis/scanner.ts
@@ -45,7 +45,7 @@ export async function cwd(
 
   try {
     const name = `${path.basename(dir)}.json`;
-    const { dependencies } = await scanner.cwd(dir, {
+    const { dependencies } = await scanner.workingDir(dir, {
       maxDepth: 4,
       vulnerabilityStrategy: "none"
     });

--- a/test/api/report.spec.ts
+++ b/test/api/report.spec.ts
@@ -188,7 +188,7 @@ PDF or HTML for packages that don't have a scorecard`, async() => {
   });
 });
 
-function isPDF(buf) {
+function isPDF(buf: Buffer) {
   return (
     Buffer.isBuffer(buf) && buf.lastIndexOf("%PDF-") === 0 && buf.lastIndexOf("%%EOF") > -1
   );


### PR DESCRIPTION
This PR updates the project to support @nodesecure/scanner v10.

Changes:
- Upgraded @nodesecure/scanner dependency to v10
- Replaced deprecated scanner.cwd usage with the new v10 API
- Updated documentation to reflect API changes

This resolves the breaking changes introduced in scanner v10.
